### PR TITLE
UILD-392: Remove non existing permission search.linked-data.work.collection.get from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,7 @@
           "linked-data.resources.preview.get",
           "linked-data.resources.import.post",
           "linked-data.profiles.get",
-          "search.linked-data.work.collection.get",
-          "search.linked-data.authority.collection.get"
+          "search.linked-data.work.collection.get"
         ]
       }
     ]


### PR DESCRIPTION
Permission  named`search.linked-data.work.collection.get` was removed from mod-search by [MSEARCH-844](https://github.com/folio-org/mod-search/pull/674/files#diff-447a26c098aa9f236a852f39464c3149d97a871c75f5b9e8ee6e968bdebe319dR720)
However, this permission is still mentioned in ui-ld-folio-wrapper's package.json file.

Purpose of this PR is to remove the non existing permission `search.linked-data.work.collection.get` from package.json