### PR TITLE
UILD-449: fix for Read-only Instance screen: 'Cancel' and X do not return user back to Inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-linked-data
 
 ## 1.1.0 (IN PROGRESS)
+* Read-only Instance screen: 'Cancel' and X do not return user back to Inventory. Fixes UILD-449
 
 
 ## 1.0.0

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -17,7 +17,7 @@ const Wrapper = ({
   history,
 }) => {
   const marvaComponent = useRef(null);
-  const { isBlocking, handleBlockedNavigation } = useBlockingNavigation(history);
+  const { isBlocking, handleBlockedNavigation } = useBlockingNavigation(history, marvaComponent);
 
   const config = {
     locale,

--- a/src/hooks/useBlockingNavigation.js
+++ b/src/hooks/useBlockingNavigation.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import useContainerEvents from './useContainerEvents';
 import {
   NAVIGATION_FROM_STORAGE_KEY,
@@ -9,11 +9,10 @@ import {
 } from '../constants/common';
 import useCreateContainerEvents from './useCreateContainerEvents';
 
-const useBlockingNavigation = (history) => {
+const useBlockingNavigation = (history, marvaComponent) => {
   const [isBlocking, setIsBlocking] = useState(false);
   const [lastLocation, setLastLocation] = useState(null);
   const [confirmedNavigation, setConfirmedNavigation] = useState(false);
-  const marvaComponent = useRef(null);
   const { eventsMap } = useCreateContainerEvents({
     history,
     setIsBlocking,

--- a/src/hooks/useBlockingNavigation.test.js
+++ b/src/hooks/useBlockingNavigation.test.js
@@ -34,8 +34,6 @@ describe('useBlockingNavigation', () => {
       },
     };
 
-    jest.spyOn(React, 'useRef').mockReturnValue(marvaComponentRef);
-
     jest.spyOn(Storage.prototype, 'setItem');
   });
 
@@ -44,7 +42,7 @@ describe('useBlockingNavigation', () => {
   });
 
   it('initializes isBlocking to false', () => {
-    const { result } = renderHook(() => useBlockingNavigation(historyMock));
+    const { result } = renderHook(() => useBlockingNavigation(historyMock, marvaComponentRef));
 
     expect(result.current.isBlocking).toBe(false);
   });
@@ -52,7 +50,7 @@ describe('useBlockingNavigation', () => {
   it('sets NAVIGATION_FROM_STORAGE_KEY when history.location.state.from exists', () => {
     historyMock.location.state = { from: '/previous-path' };
 
-    renderHook(() => useBlockingNavigation(historyMock));
+    renderHook(() => useBlockingNavigation(historyMock, marvaComponentRef));
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
       NAVIGATION_FROM_STORAGE_KEY,
@@ -63,7 +61,7 @@ describe('useBlockingNavigation', () => {
   it('replaces pathname when it includes EXTERNAL_RESOURCE_PATH_BIT', () => {
     historyMock.location.pathname = `/some-path/${EXTERNAL_RESOURCE_PATH_BIT}`;
 
-    renderHook(() => useBlockingNavigation(historyMock));
+    renderHook(() => useBlockingNavigation(historyMock, marvaComponentRef));
 
     expect(historyMock.replace).toHaveBeenCalledWith({
       pathname: `${ROUTE_PREFIX}${HOMEPAGE_URI}`,
@@ -73,13 +71,13 @@ describe('useBlockingNavigation', () => {
   it('remounts marvaComponent when pathname includes HOMEPAGE_URI', () => {
     historyMock.location.pathname = `${ROUTE_PREFIX}${HOMEPAGE_URI}`;
 
-    renderHook(() => useBlockingNavigation(historyMock));
+    renderHook(() => useBlockingNavigation(historyMock, marvaComponentRef));
 
     expect(marvaComponentRef.current.remount).toHaveBeenCalled();
   });
 
   it('returns true from handleBlockedNavigation when isBlocking is false', () => {
-    const { result } = renderHook(() => useBlockingNavigation(historyMock));
+    const { result } = renderHook(() => useBlockingNavigation(historyMock, marvaComponentRef));
 
     const nextLocation = { pathname: '/next-path' };
     const canNavigate = result.current.handleBlockedNavigation(nextLocation);


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-449](https://folio-org.atlassian.net/browse/UILD-449)