### PR TITLE
UILD-527: Add Authority lookup permissions to "Cataloger - Linked Data Editor" role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 1.4.0 (IN PROGRESS)
+## 1.3.1 (IN PROGRESS)
+* Add Authority lookup permissions to "Cataloger - Linked Data Editor" role. Fixes [UILD-527]
+
+[UILD-527]: https://folio-org.atlassian.net/browse/UILD-527
 
 ## 1.3.0 (2025-03-27)
-* Bump ui-linked-data version
+* Bump ui-linked-data version to 1.0.2
 
 ## 1.2.0 (2025-03-12)
 * Initial release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@folio/ld-folio-wrapper",
   "repository": "@folio/ui-ld-folio-wrapper",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Linked Data Editor - Folio Wrapper",
   "main": "src/index.js",
   "publishConfig": {
@@ -90,7 +90,9 @@
     ],
     "okapiInterfaces": {
       "linked-data": "1.0",
-      "search": "1.3"
+      "search": "1.3",
+      "authority-source-files": "2.2",
+      "source-storage-records": "3.4"
     },
     "permissionSets": [
       {
@@ -105,6 +107,7 @@
         "visible": true,
         "subPermissions": [
           "module.ld-folio-wrapper.enabled",
+          "inventory-storage.authority-source-files.collection.get",
           "linked-data.authority-assignment-check.post",
           "linked-data.resources.bib.get",
           "linked-data.resources.bib.post",
@@ -118,7 +121,10 @@
           "linked-data.resources.preview.get",
           "linked-data.resources.import.post",
           "linked-data.profiles.get",
-          "search.linked-data.work.collection.get"
+          "search.linked-data.work.collection.get",
+          "search.authorities.collection.get",
+          "search.facets.collection.get",
+          "source-storage.records.formatted.item.get"
         ]
       }
     ]


### PR DESCRIPTION
1. Add permissions required for authority look-up into `ui-linked-data.all` permission set.
2. Add okapi interfaces that was missed out from module descriptor   