### PR TITLE
UILD-527: Add Authority browse permissions to 'Cataloger - Linked Data Editor' role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.3.1 (IN PROGRESS)
-* Add Authority lookup permissions to "Cataloger - Linked Data Editor" role. Fixes [UILD-527]
+* Add Authority search and browse permissions to "Cataloger - Linked Data Editor" role. Fixes [UILD-527]
 * Bump ui-linked-data version to 1.0.3
 
 [UILD-527]: https://folio-org.atlassian.net/browse/UILD-527

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "okapiInterfaces": {
       "linked-data": "1.0",
       "search": "1.3",
+      "browse": "2.0",
       "authority-source-files": "2.2",
       "source-storage-records": "3.4"
     },
@@ -123,6 +124,7 @@
           "linked-data.profiles.get",
           "search.linked-data.work.collection.get",
           "search.authorities.collection.get",
+          "browse.authorities.collection.get",
           "search.facets.collection.get",
           "source-storage.records.formatted.item.get"
         ]


### PR DESCRIPTION
A minor update to [this PR](https://github.com/folio-org/ui-ld-folio-wrapper/pull/42) we merged last week.

Scope: Add Authority browse permissions to 'Cataloger - Linked Data Editor' role