### PR TITLE
UILD-571: Include linked-data-profile okapi interface and associated permissions in ModuleDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0.0 (IN PROGRESS)
 * Bump ui-linked-data version to 2.0.0
+* Bump up the version of search to 1.4
+* Include linked-data-profile okapi interface and associated permissions in ModuleDescriptor [UILD-571]
+
+[UILD-571]: https://folio-org.atlassian.net/browse/UILD-571
 
 ## 1.3.3 (2025-04-30)
 * Fix navigation handling to include search parameters when pushing last location. Fixes [UILD-531]

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     ],
     "okapiInterfaces": {
       "linked-data": "2.0",
-      "search": "1.3",
+      "linked-data-profile": "1.0",
+      "search": "1.4",
       "browse": "2.0",
       "authority-source-files": "2.2",
       "source-storage-records": "3.4"
@@ -122,6 +123,8 @@
           "linked-data.resources.preview.get",
           "linked-data.resources.import.post",
           "linked-data.profiles.get",
+          "linked-data.profiles.item.get",
+          "linked-data.profiles.metadata.get",
           "search.linked-data.work.collection.get",
           "search.authorities.collection.get",
           "browse.authorities.collection.get",


### PR DESCRIPTION
1. Include linked-data-profile okapi interface
2. Include associated permissions in ModuleDescriptor