### PR TITLE
UILD-588: Remove obsolete permission linked-data.profiles.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 * Bump ui-linked-data version to 2.0.0
 * Bump up the version of search to 1.4
 * Include linked-data-profile okapi interface and associated permissions in ModuleDescriptor [UILD-571]
+* Remove obsolete permission `linked-data.profiles.get` [UILD-588]
 
 [UILD-571]: https://folio-org.atlassian.net/browse/UILD-571
+[UILD-588]: https://folio-org.atlassian.net/browse/UILD-588
 
 ## 1.3.3 (2025-04-30)
 * Fix navigation handling to include search parameters when pushing last location. Fixes [UILD-531]

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
           "linked-data.resources.support-check.get",
           "linked-data.resources.preview.get",
           "linked-data.resources.import.post",
-          "linked-data.profiles.get",
           "linked-data.profiles.item.get",
           "linked-data.profiles.metadata.get",
           "search.linked-data.work.collection.get",


### PR DESCRIPTION
`GET linked-data/profile` and the associated permission `linked-data.profiles.get` is removed from the backend. This PR removes the permission from UI module descriptor.

Depends on https://github.com/folio-org/mod-linked-data/pull/236