### PR TITLE
UILD-620: Add mock for ui-linked-data in Jest tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 * Include linked-data-profile okapi interface and associated permissions in ModuleDescriptor [UILD-571]
 * Remove obsolete permission `linked-data.profiles.get` [UILD-588]
 * *BREAKING* Update okapiInterfaces for Split Search & Browse APIs. [UILD-595]
+* Update test configs to mock ui-linked-data. [UILD-620]
 
 [UILD-571]: https://folio-org.atlassian.net/browse/UILD-571
 [UILD-588]: https://folio-org.atlassian.net/browse/UILD-588
 [UILD-595]: https://folio-org.atlassian.net/browse/UILD-595
+[UILD-620]: https://folio-org.atlassian.net/browse/UILD-620
 
 ## 1.3.3 (2025-04-30)
 * Fix navigation handling to include search parameters when pushing last location. Fixes [UILD-531]

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
   moduleNameMapper: {
     '^.+\\.(css|png|svg)$': 'identity-obj-proxy',
+    '@folio/linked-data': '<rootDir>/test/jest/__mock__/linked-data.mock.js'
   },
   testEnvironment: 'jsdom',
   testMatch: ['**/(lib|src)/**/?(*.)test.{js,jsx}'],

--- a/test/jest/__mock__/linked-data.mock.js
+++ b/test/jest/__mock__/linked-data.mock.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn();


### PR DESCRIPTION
[https://folio-org.atlassian.net/browse/UILD-620](https://folio-org.atlassian.net/browse/UILD-620)

The tests fail because `ui-linked-data` is built as a `.ejs` module.
To solve this problem (and essentially remove any affect of the external module), this package is mocked.
 